### PR TITLE
Generate drupal_hash_salt on site install

### DIFF
--- a/drush/scratchpads.drush.inc
+++ b/drush/scratchpads.drush.inc
@@ -44,7 +44,7 @@ function scratchpads_provision_services() {
  */
 function scratchpads_validate_site_data() {
   if(isset(d()->site_data)) {
-    drush_log('site_data received from the frontend (d()->site_data): ' . d()->site_data);
+    drush_log('site_data received from the frontend (d()->site_data): ' . print_r(d()->site_data, true));
   } else {
     drush_log('No site_data was stored in the alias file', 'warning');
   }
@@ -55,4 +55,30 @@ function scratchpads_validate_site_data() {
  */
 function drush_scratchpads_post_provision_install() {
   scratchpads_validate_site_data();
+}
+
+
+/**
+ * Generate a value for $drupal_hash_salt and append it to Drupal's settings.php file
+ * If this is left blank, Drupal generates a salt on the fly each time it needs it,
+ * however it does it in a way which is different during the install process vs normal use
+ * which breaks the first-time login link.
+ * Instead we generate one during site creating, which guarantees the link to work.
+ *
+ * @param $uri
+ *   URI for the site.
+ * @param $data
+ *   Associative array of data from provisionConfig_drupal_settings::data.
+ *
+ * @return
+ *   Lines to add to the site's settings.php file.
+ *
+ * @see provisionConfig_drupal_settings
+ */
+function scratchpads_provision_drupal_config($uri, $data) {
+  // This is similar to how Drupal generates the salt - see drupal_get_hash_salt
+  $salt = hash('sha256', serialize($data));
+
+  drush_log("Scratchpads: Generating drupal_hash_salt in settings.php");
+  return "\$drupal_hash_salt = '$salt';\n";
 }


### PR DESCRIPTION
Generate a drupal_hash_salt on install to stop the login link from breaking on php7